### PR TITLE
Add missing deps

### DIFF
--- a/vendor/github.com/getsentry/raven-go/Dockerfile.test
+++ b/vendor/github.com/getsentry/raven-go/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM golang:1.7
+
+RUN mkdir -p /go/src/github.com/getsentry/raven-go
+WORKDIR /go/src/github.com/getsentry/raven-go
+ENV GOPATH /go
+
+RUN go install -race std && go get golang.org/x/tools/cmd/cover
+
+COPY . /go/src/github.com/getsentry/raven-go
+
+RUN go get -v ./...
+
+CMD ["./runtests.sh"]


### PR DESCRIPTION
Dockerfile.test is hidden by .gitignore, however it's necessary to be in the repository so make verify-deps passes.