### PR TITLE
Bump OCP version in image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,aws-ebs-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.4:aws-ebs-csi-driver-operator,./Dockerfile.rhel7,.)
+$(call build-image,aws-ebs-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.5:aws-ebs-csi-driver-operator,./Dockerfile.rhel7,.)
 
 # generate bindata targets
 # $0 - macro name


### PR DESCRIPTION
Default to `registry.svc.ci.openshift.org/ocp/4.5:aws-ebs-csi-driver-operator`