### PR TITLE
Bump openshift/library-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,4 @@ $ OPERAND_IMAGE_VERSION=0.1 OPERAND_IMAGE=quay.io/bertinatto/my-custom-aws-ebs-c
 
 - [ ] In ApplyStorageClass(), recreate Storage class if the new one changes an immutable field.
     - Currently, if we release a new version of the operator with a different StorageClass (with a different immutable field), ApplyStorageClass() will fail indefinitely
-- [ ] Get https://github.com/openshift/library-go/pull/759/ merged
-	- Once that's merged, update openshift/library-go dependency
 - [ ] Create function to replace `deleteAll()` from this operator

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20200326160804-ecb9283fe820
 	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/openshift/library-go v0.0.0-20200326170900-bf62907daa13
+	github.com/openshift/library-go v0.0.0-20200331191807-3eb0070c91ed
 	github.com/prometheus/client_golang v1.4.1
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
-github.com/openshift/library-go v0.0.0-20200326170900-bf62907daa13 h1:W0X+nMlzg628NA3hRuDl3X4BDyKn2dSGFbOOsGTfxK8=
-github.com/openshift/library-go v0.0.0-20200326170900-bf62907daa13/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
+github.com/openshift/library-go v0.0.0-20200331191807-3eb0070c91ed h1:7dAzYWRjXQDPVBtkoaLLLeYXE/sRv0fXnACxDxGBX/E=
+github.com/openshift/library-go v0.0.0-20200331191807-3eb0070c91ed/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20200326170900-bf62907daa13
+# github.com/openshift/library-go v0.0.0-20200331191807-3eb0070c91ed
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/config/configdefaults


### PR DESCRIPTION
CC @openshift/storage 

This fixes an issue where the StorageClass was always updated when the operator syncs.