### PR TITLE
Rework e2e tests from Makefile to a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SHELL :=/bin/bash
-ARTIFACT_DIR ?= "_output/e2e"
 
 all: build
 .PHONY: all
@@ -68,8 +67,6 @@ GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 # Example:
 #   make test-e2e
 test-e2e:
-	hack/start.sh
-	mkdir -p $(ARTIFACT_DIR)
-	TEST_CSI_DRIVER_FILES=test/e2e/manifest.yaml openshift-tests run openshift/csi -o $(ARTIFACT_DIR)/e2e.log --junit-dir $(ARTIFACT_DIR)/junit
+	hack/e2e.sh
 
 .PHONY: test-e2e

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+repo_dir="$(dirname $0)/.."
+
+# Prepare openshift-tests arguments for log output
+additional_test_args=""
+if [ -n "${ARTIFACT_DIR}" ]; then
+    mkdir -p ${ARTIFACT_DIR}
+    additional_test_args="-o ${ARTIFACT_DIR}/e2e.log --junit-dir ${ARTIFACT_DIR}/junit"
+fi
+
+# Start the operator
+${repo_dir}/hack/start.sh
+
+# Run openshift-tests
+TEST_CSI_DRIVER_FILES=${repo_dir}/test/e2e/manifest.yaml openshift-tests run openshift/csi $additional_test_args

--- a/hack/start.sh
+++ b/hack/start.sh
@@ -81,11 +81,11 @@ EOF
 
 repo_dir="$(dirname $0)/.."
 
-cp -v ${repo_dir}/manifests/*.yaml ${manifest}/
+cp ${repo_dir}/manifests/*.yaml ${manifest}/
 
 for infile in $( ls ${repo_dir}/hack/start-manifests/*.yaml ); do
     outfile=${manifest}/$( basename ${infile} )
-    cp -v ${infile} ${outfile}
+    cp ${infile} ${outfile}
     sed -i -f ${manifest}/.sedscript ${outfile}
 done
 


### PR DESCRIPTION
Second attempt to add e2e tests to this repo.

There is no `/bin/make` in our e2e, create a bash script.