### PR TITLE
Make credentials secret required

### DIFF
--- a/assets/controller_deployment.yaml
+++ b/assets/controller_deployment.yaml
@@ -37,13 +37,11 @@ spec:
                 secretKeyRef:
                   name: aws-cloud-credentials
                   key: aws_access_key_id
-                  optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: aws-cloud-credentials
                   key: aws_secret_access_key
-                  optional: true
           ports:
             - name: healthz
               containerPort: 19808

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -101,13 +101,11 @@ spec:
                 secretKeyRef:
                   name: aws-cloud-credentials
                   key: aws_access_key_id
-                  optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: aws-cloud-credentials
                   key: aws_secret_access_key
-                  optional: true
           ports:
             - name: healthz
               containerPort: 19808


### PR DESCRIPTION
The controller pods should not start until a secret with AWS credentials is present.

With this patch, controller pods are in `CreateContainerConfigError` state with this event until the secret is present:

    Error: secret "aws-cloud-credentials" not found