### PR TITLE
Add image with e2e test scripts & manifests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,11 @@
+# This image contains scripts and YAML manifests for e2e tests.
+# It is going to be used to install the operator in prow jobs
+# of all sidecars & AWS EBS CSI driver to prevent regressions.
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+WORKDIR /go/src/github.com/openshift/aws-ebs-csi-driver-operator
+
+# Make a full copy of the operator sources for now to be able
+# to experiment in a prow job without changing this image.
+# TODO: extract just the files we need for e2e.
+COPY . .


### PR DESCRIPTION
The new image is going to be used in e2e tests of other images (sidecars, AWS EBS CSI driver, origin) to get to scripts & manifests of the operator.

Copying all files for now - refactoring both in corresponding prow jobs and in this repo (at lease `hack/` and `manifest/`)  is expected and I want to avoid changing the image every time I need another file in the prow job.