### PR TITLE
Validate CR name

### DIFF
--- a/manifests/4.5/aws-csi-driver.crd.yaml
+++ b/manifests/4.5/aws-csi-driver.crd.yaml
@@ -38,6 +38,12 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
+              # Force "cluster" as CR name.
+              enum:
+               - cluster
         spec:
           description:
             DriverSpec is the specification of the desired behavior of


### PR DESCRIPTION
Only `name: cluster` is allowed. Using `enum`, because it has better error message than `pattern:`

With `enum`:
```
The Driver "clusterX" is invalid: metadata.name: Unsupported value: "clusterX": supported values: "cluster"
```

With `pattern: "^cluster$"`:
```
The Driver "clusterX" is invalid: metadata.name: Invalid value: "": metadata.name in body should match '^cluster$'
```
Fixes: #21