### PR TITLE
Finish e2e test preparation

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,11 +1,5 @@
-# This image contains scripts and YAML manifests for e2e tests.
-# It is going to be used to install the operator in prow jobs
-# of all sidecars & AWS EBS CSI driver to prevent regressions.
+# "src" is build by a prow job when building final images.
+# It contains full repository sources + jq + pyhon with yaml module.
+# Use it as test image for the operator.
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-WORKDIR /go/src/github.com/openshift/aws-ebs-csi-driver-operator
-
-# Make a full copy of the operator sources for now to be able
-# to experiment in a prow job without changing this image.
-# TODO: extract just the files we need for e2e.
-COPY . .
+FROM src

--- a/hack/start.sh
+++ b/hack/start.sh
@@ -60,6 +60,7 @@ REPO_ROOT="$(dirname $0)/.."
 OCP_VERSION=${OCP_VERSION:-4.5}
 YAML2JSON=$REPO_ROOT/hack/yaml2json.py
 IMAGE_FORMAT=${IMAGE_FORMAT:-""}
+ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 MANIFEST=$(mktemp -d)
 trap cleanup exit
 


### PR DESCRIPTION
Another e2e preparation PR... Now the set up is easier: ship whole repository in Dockerfile.test. Using "src", because it contains the repo + `jq` + python yaml module.
 
This image will be run in e2e jobs, with `oc` and `openshift-tests` injected there, see https://github.com/openshift/release/pull/8067 for details.

\+ fix one potentially uninitalized variable in e2e scripts