### PR TITLE
Update the operand when image changes

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -68,14 +68,16 @@ const (
 )
 
 type csiDriverOperator struct {
-	client          OperatorClient
-	kubeClient      kubernetes.Interface
-	dynamicClient   dynamic.Interface
-	pvInformer      coreinformersv1.PersistentVolumeInformer
-	secretInformer  coreinformersv1.SecretInformer
-	versionGetter   status.VersionGetter
-	eventRecorder   events.Recorder
-	informersSynced []cache.InformerSynced
+	client             OperatorClient
+	kubeClient         kubernetes.Interface
+	dynamicClient      dynamic.Interface
+	pvInformer         coreinformersv1.PersistentVolumeInformer
+	secretInformer     coreinformersv1.SecretInformer
+	deploymentInformer appsinformersv1.DeploymentInformer
+	dsSetInformer      appsinformersv1.DaemonSetInformer
+	versionGetter      status.VersionGetter
+	eventRecorder      events.Recorder
+	informersSynced    []cache.InformerSynced
 
 	syncHandler func() error
 
@@ -119,17 +121,19 @@ func NewCSIDriverOperator(
 	images images,
 ) *csiDriverOperator {
 	csiOperator := &csiDriverOperator{
-		client:          client,
-		kubeClient:      kubeClient,
-		dynamicClient:   dynamicClient,
-		pvInformer:      pvInformer,
-		secretInformer:  secretInformer,
-		versionGetter:   versionGetter,
-		eventRecorder:   eventRecorder,
-		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "aws-ebs-csi-driver"),
-		operatorVersion: operatorVersion,
-		operandVersion:  operandVersion,
-		images:          images,
+		client:             client,
+		kubeClient:         kubeClient,
+		dynamicClient:      dynamicClient,
+		pvInformer:         pvInformer,
+		secretInformer:     secretInformer,
+		deploymentInformer: deployInformer,
+		dsSetInformer:      dsInformer,
+		versionGetter:      versionGetter,
+		eventRecorder:      eventRecorder,
+		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "aws-ebs-csi-driver"),
+		operatorVersion:    operatorVersion,
+		operandVersion:     operandVersion,
+		images:             images,
 	}
 
 	csiOperator.informersSynced = append(csiOperator.informersSynced, pvInformer.Informer().HasSynced)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -25,13 +27,14 @@ import (
 )
 
 const (
-	csiDriver         = "csidriver.yaml"
-	namespace         = "namespace.yaml"
-	serviceAccount    = "serviceaccount.yaml"
-	storageClass      = "storageclass.yaml"
-	daemonSet         = "node_daemonset.yaml"
-	deployment        = "controller_deployment.yaml"
-	credentialsSecret = "aws-cloud-credentials"
+	csiDriver          = "csidriver.yaml"
+	namespace          = "namespace.yaml"
+	serviceAccount     = "serviceaccount.yaml"
+	storageClass       = "storageclass.yaml"
+	daemonSet          = "node_daemonset.yaml"
+	deployment         = "controller_deployment.yaml"
+	credentialsSecret  = "aws-cloud-credentials"
+	specHashAnnotation = "operator.openshift.io/spec-hash"
 )
 
 var (
@@ -60,22 +63,12 @@ var (
 func (c *csiDriverOperator) syncDeployment(instance *v1alpha1.Driver) (*appsv1.Deployment, error) {
 	deploy := c.getExpectedDeployment(instance)
 
-	// Update the deployment when something updated Driver.Spec.LogLevel.
-	// The easiest check is for Generation update (i.e. redeploy on any Driver.Spec change).
-	// This may update the Deployment more than it is strictly necessary, but the overhead is not that big.
-	forceRollout := false
-	if instance.Generation != instance.Status.ObservedGeneration {
-		forceRollout = true
-	}
-
-	if c.versionChanged("operator", c.operatorVersion) {
-		// Operator version changed. The new one _may_ have updated Deployment -> we should deploy it.
-		forceRollout = true
-	}
-
-	if c.versionChanged("aws-ebs-csi-driver", c.operandVersion) {
-		// Operand version changed. Update the deployment with a new image.
-		forceRollout = true
+	// Record the hash of the spec in an annotation so ApplyDeployment
+	// below detects its change. This is going to cover log level, image
+	// and/or bindata changes.
+	// TODO: use resourceapply.ApplyDeployment when it gets hashing of Spec.
+	if err := addDeploymentHash(deploy); err != nil {
+		return nil, err
 	}
 
 	deploy, _, err := resourceapply.ApplyDeployment(
@@ -83,7 +76,7 @@ func (c *csiDriverOperator) syncDeployment(instance *v1alpha1.Driver) (*appsv1.D
 		c.eventRecorder,
 		deploy,
 		resourcemerge.ExpectedDeploymentGeneration(deploy, instance.Status.Generations),
-		forceRollout)
+		false)
 	if err != nil {
 		return nil, err
 	}
@@ -94,22 +87,12 @@ func (c *csiDriverOperator) syncDeployment(instance *v1alpha1.Driver) (*appsv1.D
 func (c *csiDriverOperator) syncDaemonSet(instance *v1alpha1.Driver) (*appsv1.DaemonSet, error) {
 	daemonSet := c.getExpectedDaemonSet(instance)
 
-	// Update the daemonSet when something updated Driver.Spec.LogLevel.
-	// The easiest check is for Generation update (i.e. redeploy on any Driver.Spec change).
-	// This may update the DaemonSet more than it is strictly necessary, but the overhead is not that big.
-	forceRollout := false
-	if instance.Generation != instance.Status.ObservedGeneration {
-		forceRollout = true
-	}
-
-	if c.versionChanged("operator", c.operatorVersion) {
-		// Operator version changed. The new one _may_ have updated DaemonSet -> we should deploy it.
-		forceRollout = true
-	}
-
-	if c.versionChanged("aws-ebs-csi-driver", c.operandVersion) {
-		// Operand version changed. Update the deployment with a new image.
-		forceRollout = true
+	// Record the hash of the spec in an annotation so ApplyDaemonSet
+	// below detects its change. This is going to cover log level, image
+	// and/or bindata changes.
+	// TODO: use resourceapply.ApplyDaemonSet when it gets hashing of Spec.
+	if err := addDaemonSetHash(daemonSet); err != nil {
+		return nil, err
 	}
 
 	daemonSet, _, err := resourceapply.ApplyDaemonSet(
@@ -117,7 +100,7 @@ func (c *csiDriverOperator) syncDaemonSet(instance *v1alpha1.Driver) (*appsv1.Da
 		c.eventRecorder,
 		daemonSet,
 		resourcemerge.ExpectedDaemonSetGeneration(daemonSet, instance.Status.Generations),
-		forceRollout)
+		false)
 	if err != nil {
 		return nil, err
 	}
@@ -514,4 +497,30 @@ func reportDeleteEvent(recorder events.Recorder, obj runtime.Object, originalErr
 	default:
 		recorder.Eventf(fmt.Sprintf("%sDeleted", gvk.Kind), "Deleted %s:\n%s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
 	}
+}
+
+func addDeploymentHash(deployment *appsv1.Deployment) error {
+	jsonBytes, err := json.Marshal(deployment.Spec)
+	if err != nil {
+		return err
+	}
+	specHash := fmt.Sprintf("%x", sha256.Sum256(jsonBytes))
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+	deployment.Annotations[specHashAnnotation] = specHash
+	return nil
+}
+
+func addDaemonSetHash(daemonSet *appsv1.DaemonSet) error {
+	jsonBytes, err := json.Marshal(daemonSet.Spec)
+	if err != nil {
+		return err
+	}
+	specHash := fmt.Sprintf("%x", sha256.Sum256(jsonBytes))
+	if daemonSet.Annotations == nil {
+		daemonSet.Annotations = map[string]string{}
+	}
+	daemonSet.Annotations[specHashAnnotation] = specHash
+	return nil
 }


### PR DESCRIPTION
The operator may need to update the operands (Deployment, DaemonSet) when:
* The images are changed by env. variables.
* Log level changes in CR.
* New operator starts and has updated bindata.

It's nearly impossible to detect these changes, therefore hash whole Deployment / DaemonSet .Spec and make sure the new objects are applied when the hash gets different.

cc @bertinatto @gnufied