### PR TITLE
Wait for pods before starting e2e tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -14,5 +14,16 @@ fi
 # Start the operator
 ${REPO_ROOT}/hack/start.sh
 
+# Wait for the CSI driver to get deployed. This is necessary for topology tests
+# - they need the driver on all nodes.
+
+# Step1: The operator says it's available (at least some pods are running).
+echo "Waiting for drivers.ebs.aws.csi.openshift.io/cluster"
+oc wait drivers.ebs.aws.csi.openshift.io/cluster --for=condition=Available --timeout=5m
+
+# Step2: Wait for *all* pods to be running.
+echo "Waiting for all driver pods"
+oc wait -n openshift-aws-ebs-csi-driver pod --all --for=condition=Ready --timeout=5m
+
 # Run openshift-tests
 TEST_CSI_DRIVER_FILES=${REPO_ROOT}/test/e2e/manifest.yaml openshift-tests run openshift/csi $ADDITIONAL_TEST_ARGS


### PR DESCRIPTION
Topology tests need all nodes to have the driver and propagate their topology to Node objects.

This could de-flake topology tests, e.g. in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_csi-external-provisioner/28/pull-ci-openshift-csi-external-provisioner-master-e2e-aws-csi/3

cc @gnufied @bertinatto 