### PR TITLE
Report events as related to the CR

### DIFF
--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -20,7 +20,6 @@ import (
 	fakecore "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 
-	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/status"
 
@@ -139,7 +138,6 @@ func newOperator(test operatorTest) *testContext {
 		dynamicClient.credentialRequest = test.initialObjects.credentialsRequest
 	}
 
-	recorder := events.NewInMemoryRecorder("operator")
 	op := NewCSIDriverOperator(client,
 		coreInformerFactory.Core().V1().PersistentVolumes(),
 		coreInformerFactory.Core().V1().Namespaces(),
@@ -154,7 +152,6 @@ func newOperator(test operatorTest) *testContext {
 		coreClient,
 		dynamicClient,
 		versionGetter,
-		recorder,
 		testVersion,
 		testVersion,
 		test.images,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -80,7 +80,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		ctrlCtx.ClientBuilder.KubeClientOrDie(operandName),
 		dynamicClient,
 		versionGetter,
-		controllerConfig.EventRecorder,
 		os.Getenv(operatorVersionEnvName),
 		os.Getenv(operandVersionEnvName),
 		imagesFromEnv(),


### PR DESCRIPTION
library-go's EventRecorder marks the operator Deployment as "related" object of the events it reports. The operator should report the events are related to the CR.

Fixes: #41

With this PR:

```
$ oc describe driver
Events:
  Type    Reason                     Age   From                                   Message
  ----    ------                     ----  ----                                   -------
  Normal  NamespaceCreated           17m   openshift-aws-ebs-csi-driver-operator  Created Namespace/openshift-aws-ebs-csi-driver because it was missing
  Normal  CSIDriverCreated           17m   openshift-aws-ebs-csi-driver-operator  Created CSIDriver.storage.k8s.io/ebs.csi.aws.com because it was missing
  Normal  CredentialsRequestCreated  17m   openshift-aws-ebs-csi-driver-operator  Created CredentialsRequest.cloudcredential.openshift.io/openshift-aws-ebs-csi-driver -n openshift-cloud-credential-operator because it was missing
  Normal  SyncError                  17m   openshift-aws-ebs-csi-driver-operator  Error syncing CSI driver: waiting for cloud credentials secret provided by cloud-credential-operator
  Normal  ClusterRoleCreated         17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRole.rbac.authorization.k8s.io/ebs-external-provisioner-role because it was missing
  Normal  ServiceAccountCreated      17m   openshift-aws-ebs-csi-driver-operator  Created ServiceAccount/aws-ebs-csi-driver-controller-sa -n openshift-aws-ebs-csi-driver because it was missing
  Normal  ServiceAccountCreated      17m   openshift-aws-ebs-csi-driver-operator  Created ServiceAccount/aws-ebs-csi-driver-node-sa -n openshift-aws-ebs-csi-driver because it was missing
  Normal  ClusterRoleCreated         17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRole.rbac.authorization.k8s.io/ebs-external-attacher-role because it was missing
  Normal  ClusterRoleCreated         17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRole.rbac.authorization.k8s.io/ebs-external-resizer-role because it was missing
  Normal  ClusterRoleCreated         17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRole.rbac.authorization.k8s.io/ebs-external-snapshotter-role because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-csi-provisioner-binding because it was missing
  Normal  ClusterRoleCreated         17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRole.rbac.authorization.k8s.io/ebs-privileged-role because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-csi-attacher-binding because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-csi-resizer-binding because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-csi-snapshotter-binding because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-controller-privileged-binding because it was missing
  Normal  ClusterRoleBindingCreated  17m   openshift-aws-ebs-csi-driver-operator  Created ClusterRoleBinding.rbac.authorization.k8s.io/ebs-node-privileged-binding because it was missing
  Normal  DeploymentCreated          17m   openshift-aws-ebs-csi-driver-operator  Created Deployment.apps/aws-ebs-csi-driver-controller -n openshift-aws-ebs-csi-driver because it was missing
  Normal  DaemonSetCreated           17m   openshift-aws-ebs-csi-driver-operator  Created DaemonSet.apps/aws-ebs-csi-driver-node -n openshift-aws-ebs-csi-driver because it was missing
  Normal  StorageClassCreated        17m   openshift-aws-ebs-csi-driver-operator  Created StorageClass.storage.k8s.io/gp2-csi because it was missing
```

There are still some events reported on the operator Deployment! They are reported from deep-inside of library-go and it's not possible to change them easily.

```
$ oc -n openshift-aws-ebs-csi-driver-operator get event
18m         Normal   LeaderElection           configmap/aws-ebs-csi-driver-operator-lock        8d99399a-756a-4233-868b-740d1a790887 became leader
18m         Normal   OperatorLogLevelChange   namespace/openshift-aws-ebs-csi-driver-operator   Operator log level changed from "Debug" to "Trace"
```