### PR TITLE
Bug 1826285: Don't delete driver if CR doesn't exist

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -195,7 +195,7 @@ func (c *csiDriverOperator) sync() error {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Warningf("Operator instance not found: %v", err)
-			return c.deleteAll()
+			return nil
 		}
 		return err
 	}


### PR DESCRIPTION
Currently, if the operator tries to delete the CSI driver if the CR doesn't exist. This behaviour was introduced before we started using a finalizer (1fd546053c751a17f86d8c5fd92ef7b81715ea1b).

With this patch, the operator will delete the driver **only** if the CR has a deletion timestamp. It keeps logging a warning when the CR isn't found.

CC @openshift/storage 