### PR TITLE
Bug 1835716: Allow the operator to be installed only once

### DIFF
--- a/bundle/manifests/aws-ebs-csi-driver-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-ebs-csi-driver-operator.clusterserviceversion.yaml
@@ -53,9 +53,9 @@ spec:
       alm-owner-metering: aws-ebs-csi-driver-operator
   installModes:
   - type: OwnNamespace
-    supported: true
+    supported: false
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces


### PR DESCRIPTION
By using AllNamespaces installMode only. OLM won't allow the operator to be installed for second time with this mode.

@openshift/storage 