### PR TITLE
Bug 1835778: Detect CSI driver installed by cluster admin

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -2,6 +2,9 @@ apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com
+  annotations:
+      # This CSIDriver is managed by an OCP CSI operator
+      csi.openshift.io/managed: "true"
 spec:
   attachRequired: true
   podInfoOnMount: false

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -253,6 +253,9 @@ var _csidriverYaml = []byte(`apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com
+  annotations:
+      # This CSIDriver is managed by an OCP CSI operator
+      csi.openshift.io/managed: "true"
 spec:
   attachRequired: true
   podInfoOnMount: false

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -67,6 +67,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		ctrlCtx.KubeNamespacedInformerFactory.Core().V1().PersistentVolumes(),
 		ctrlCtx.KubeNamespacedInformerFactory.Core().V1().Namespaces(),
 		ctrlCtx.KubeNamespacedInformerFactory.Storage().V1beta1().CSIDrivers(),
+		ctrlCtx.KubeNamespacedInformerFactory.Storage().V1beta1().CSINodes(),
 		ctrlCtx.KubeNamespacedInformerFactory.Core().V1().ServiceAccounts(),
 		ctrlCtx.KubeNamespacedInformerFactory.Rbac().V1().ClusterRoles(),
 		ctrlCtx.KubeNamespacedInformerFactory.Rbac().V1().ClusterRoleBindings(),

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -302,13 +302,21 @@ func (c *csiDriverOperator) syncStatus(instance *v1alpha1.AWSEBSDriver, deployme
 	return nil
 }
 
-func (c *csiDriverOperator) syncConditions(instance *v1alpha1.AWSEBSDriver, deployment *appsv1.Deployment, daemonSet *appsv1.DaemonSet) {
-	// The operator does not have any prerequisites (at least now)
+func (c *csiDriverOperator) setCondition(instance *v1alpha1.AWSEBSDriver, condition string, value bool, reason, msg string) {
+	v := operatorv1.ConditionFalse
+	if value {
+		v = operatorv1.ConditionTrue
+	}
 	v1helpers.SetOperatorCondition(&instance.Status.OperatorStatus.Conditions,
 		operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypePrereqsSatisfied,
-			Status: operatorv1.ConditionTrue,
+			Type:    condition,
+			Status:  v,
+			Reason:  reason,
+			Message: msg,
 		})
+}
+
+func (c *csiDriverOperator) syncConditions(instance *v1alpha1.AWSEBSDriver, deployment *appsv1.Deployment, daemonSet *appsv1.DaemonSet) {
 	// The operator is always upgradeable (at least now)
 	v1helpers.SetOperatorCondition(&instance.Status.OperatorStatus.Conditions,
 		operatorv1.OperatorCondition{


### PR DESCRIPTION
The operator should refuse to manage CSI driver that has been installed manully by cluster admin (or another operator).

"CSI driver that has been installed manually" is detected this way:
- CSIDriver exists and does not have OCP annotation.
- OR CSIDriver does not exist
  - AND namespace `opesnhift-aws-ebs-csi-driver` does not exist
  - AND there is at least one CSINode that has the driver

To properly report Progressing and PrereqSatisfied conditions, condition handling has been changed considerably.