### PR TITLE
Bug 1835726: Actually use error message from the credentials operator

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -322,7 +322,11 @@ func (c *csiDriverOperator) handleSync(instance *v1alpha1.AWSEBSDriver) error {
 	err = c.tryCredentialsSecret(instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Have a nice event instead of "secret XYZ not found"
+			// Get the error message from credentialsRequest first
+			if msg := getCredentialsRequestFailure(credentialsRequest); msg != "" {
+				return fmt.Errorf("failed to obtain cloud credentials: %s", msg)
+			}
+			// Fall back to a generic message. Use something better than "secret XYZ not found".
 			return fmt.Errorf("waiting for cloud credentials secret provided by cloud-credential-operator")
 		}
 		return fmt.Errorf("error waiting for cloud credentials:: %v", err)


### PR DESCRIPTION
The previous PR #54 did not include sending the message from cloud credentials operator, add it here.

@openshift/storage 