### PR TITLE
Bug 1839720: Revert "Add defaulting to driver.Spec fields"

### DIFF
--- a/bundle/manifests/aws-csi-driver.crd.yaml
+++ b/bundle/manifests/aws-csi-driver.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: awsebsdrivers.csi.openshift.io
@@ -10,167 +10,165 @@ spec:
     singular: awsebsdriver
   preserveUnknownFields: false
   scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
+  validation:
+    openAPIV3Schema:
+      description:
+        AWSEBSDriver provides information to configure an operator to
+        manage the AWS EBS CSI driver.
+      type: object
+      properties:
+        apiVersion:
           description:
-            AWSEBSDriver provides information to configure an operator to
-            manage the AWS EBS CSI driver.
+            "APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          type: string
+        kind:
+          description:
+            "Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          type: string
+        metadata:
           type: object
           properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+            name:
               type: string
-            kind:
+              # Force "cluster" as CR name.
+              enum:
+               - cluster
+        spec:
+          description:
+            AWSEBSDriverSpec is the specification of the desired behavior of
+            the AWS EBS CSI driver operator.
+          type: object
+          properties:
+            logLevel:
               description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
               type: string
-            metadata:
-              type: object
-              properties:
-                name:
-                  type: string
-                  # Force "cluster" as CR name.
-                  enum:
-                   - cluster
-            spec:
+              enum:
+               - Normal
+               - Debug
+               - Trace
+               - TraceAll
+            managementState:
               description:
-                AWSEBSDriverSpec is the specification of the desired behavior of
-                the AWS EBS CSI driver operator.
-              type: object
-              properties:
-                logLevel:
-                  description:
-                    logLevel is an intent based logging for an overall component.  It
-                    does not give fine grained control, but it is a simple way to manage
-                    coarse grained logging choices that operators have to interpret for
-                    their operands.
-                  type: string
-                  enum:
-                   - Normal
-                   - Debug
-                   - Trace
-                   - TraceAll
-                  default: Normal
-                managementState:
-                  description:
-                    managementState indicates whether and how the operator
-                    should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                  default: Managed
-                observedConfig:
-                  description:
-                    observedConfig holds a sparse config that controller has
-                    observed from the cluster state.  It exists in spec because it is
-                    an input to the level for the operator
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description:
-                    operatorLogLevel is an intent based logging for the operator
-                    itself.  It does not give fine grained control, but it is a simple
-                    way to manage coarse grained logging choices that operators have to
-                    interpret for themselves.
-                  type: string
-                  enum:
-                   - Normal
-                   - Debug
-                   - Trace
-                   - TraceAll
-                  default: Normal
-                unsupportedConfigOverrides:
-                  description:
-                    "unsupportedConfigOverrides holds a sparse config that
-                    will override any previously set options.  It only needs to be the
-                    fields to override it will end up overlaying in the following order:
-                    1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides"
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
+                managementState indicates whether and how the operator
+                should manage the component
+              type: string
+              pattern: ^(Managed|Unmanaged|Force|Removed)$
+            observedConfig:
               description:
-                AWSEBSDriverStatus defines the observed status of
-                the AWS EBS CSI driver operator.
+                observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator
               type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description:
-                    generations are used to determine when an item needs to
-                    be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            operatorLogLevel:
+              description:
+                operatorLogLevel is an intent based logging for the operator
+                itself.  It does not give fine grained control, but it is a simple
+                way to manage coarse grained logging choices that operators have to
+                interpret for themselves.
+              type: string
+              enum:
+               - Normal
+               - Debug
+               - Trace
+               - TraceAll
+            unsupportedConfigOverrides:
+              description:
+                "unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides"
+              type: object
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+        status:
+          description:
+            AWSEBSDriverStatus defines the observed status of
+            the AWS EBS CSI driver operator.
+          type: object
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              type: array
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            generations:
+              description:
+                generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description:
+                  GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
                     description:
-                      GenerationStatus keeps track of the generation for a
-                      given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description:
-                          hash is an optional field set for resources without
-                          generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description:
-                          lastGeneration is the last generation of the workload
-                          controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description:
-                          resource is the resource type of the thing you're
-                          tracking
-                        type: string
-                observedGeneration:
-                  description:
-                    observedGeneration is the last generation change you've
-                    dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description:
-                    readyReplicas indicates how many replicas are ready and
-                    at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
+                      hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description:
+                      lastGeneration is the last generation of the workload
+                      controller involved
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description:
+                      resource is the resource type of the thing you're
+                      tracking
+                    type: string
+            observedGeneration:
+              description:
+                observedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            readyReplicas:
+              description:
+                readyReplicas indicates how many replicas are ready and
+                at the desired state
+              type: integer
+              format: int32
+            version:
+              description: version is the level this availability applies to
+              type: string


### PR DESCRIPTION
This reverts commit 708230e049bc9ece879f52ee865dfbc6c967eb07.

Restore v1beta1 CRD, our operator pipeline does not support v1 yet. I reopened https://bugzilla.redhat.com/show_bug.cgi?id=1835604 to fix it later, when we have bundle images.