### PR TITLE
Fix the operator images and assets

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -47,6 +47,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
@@ -60,6 +64,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-attacher
           image: ${ATTACHER_IMAGE}
           args:
@@ -71,6 +79,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-resizer
           image: ${RESIZER_IMAGE}
           args:
@@ -82,6 +94,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-snapshotter
           image: ${SNAPSHOTTER_IMAGE}
           args:
@@ -93,6 +109,10 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/csi/sockets/pluginproxy/
             name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -50,6 +50,10 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true
@@ -72,6 +76,10 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           args:
@@ -80,6 +88,10 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -36,7 +36,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: quay.io/bertinatto/aws-ebs-csi-driver-operator:lib
+        image: quay.io/openshift/origin-aws-ebs-csi-driver-operator:latest
         imagePullPolicy: Always
         name: aws-ebs-csi-driver-operator
       priorityClassName: system-cluster-critical

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -121,6 +121,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
@@ -134,6 +138,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-attacher
           image: ${ATTACHER_IMAGE}
           args:
@@ -145,6 +153,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-resizer
           image: ${RESIZER_IMAGE}
           args:
@@ -156,6 +168,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-snapshotter
           image: ${SNAPSHOTTER_IMAGE}
           args:
@@ -167,6 +183,10 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/csi/sockets/pluginproxy/
             name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -357,6 +377,10 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true
@@ -379,6 +403,10 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           args:
@@ -387,6 +415,10 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: kubelet-dir
           hostPath:


### PR DESCRIPTION
Adding memory/cpu requirements, which should move the QoS from BestEffort to Burstable.

See https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-storage-operator/59/pull-ci-openshift-cluster-storage-operator-master-e2e-aws/1288039129833017344

@openshift/storage 