### PR TITLE
Don't use Always pull policy

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: quay.io/openshift/origin-aws-ebs-csi-driver-operator:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: aws-ebs-csi-driver-operator
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-ebs-csi-driver-operator


### PR DESCRIPTION
OCP must use IfNotPresent. There is a test in e2e that catches this.

@openshift/storage 