### PR TITLE
Bug 1863055: CSI drivers should tolerate any taints

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -16,8 +16,7 @@ spec:
       serviceAccount: aws-ebs-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -343,8 +343,7 @@ spec:
       serviceAccount: aws-ebs-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:


### PR DESCRIPTION
Any node should be able to use PVCs. We don't know in advance what taints will be used in the cluster.

@openshift/storage 