### PR TITLE
Use installed StorageClass for tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -1,7 +1,7 @@
 # Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
 ShortName: ebs
 StorageClass:
-  FromFile: storageclass.yaml
+  FromExistingClassName: gp2-csi
 SnapshotClass:
   FromName: true
 DriverInfo:

--- a/test/e2e/storageclass.yaml
+++ b/test/e2e/storageclass.yaml
@@ -1,6 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: ebs.csi.aws.com
-provisioner: ebs.csi.aws.com
-volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
The storage class should be created during cluster setup. It simplifies subsequent e2e tests, as they don't need to find storage class YAML and make sure it's in the right directory (i.e. in the current directory where the tests run).