### PR TITLE
Bug 1871051: Add external-attacher permissions to patch status

### DIFF
--- a/assets/rbac/attacher_role.yaml
+++ b/assets/rbac/attacher_role.yaml
@@ -15,3 +15,6 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]

--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -164,6 +164,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotcontents/status

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -521,6 +521,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 `)
 
 func rbacAttacher_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
v3.0.0 of the external-attacher uses PATCH to update `volumeattachment/status`