### PR TITLE
Bug 1871998: Schedule CSI Controller on master nodes

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -17,9 +17,14 @@ spec:
       hostNetwork: true
       serviceAccount: aws-ebs-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -41,6 +41,11 @@ spec:
         name: aws-ebs-csi-driver-operator
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-ebs-csi-driver-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -91,9 +91,14 @@ spec:
       hostNetwork: true
       serviceAccount: aws-ebs-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}


### PR DESCRIPTION
Controllers should run on master nodes. Operators should run on master nodes as well, so update the operator manifest too (although it's here just for reference, as the the CSO uses the manifest from its own repo.

CC @openshift/storage 
