### PR TITLE
Bug 1876791: Update provisioner container to v2.0.0

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -59,7 +59,6 @@ spec:
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
-            - --provisioner=ebs.csi.aws.com
             - --csi-address=$(ADDRESS)
             - --feature-gates=Topology=true
             - --v=${LOG_LEVEL}

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -132,7 +132,6 @@ spec:
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
-            - --provisioner=ebs.csi.aws.com
             - --csi-address=$(ADDRESS)
             - --feature-gates=Topology=true
             - --v=${LOG_LEVEL}


### PR DESCRIPTION
* `--provisioner` has been deprecated and removed upstream.

@openshift/storage 
