### PR TITLE
Bug 1877084: Increase resizer timeout to 300s

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -92,7 +92,7 @@ spec:
           image: ${RESIZER_IMAGE}
           args:
             - --csi-address=$(ADDRESS)
-            - --timeout=120s
+            - --timeout=300s
             - --v=${LOG_LEVEL}
           env:
             - name: ADDRESS

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -165,7 +165,7 @@ spec:
           image: ${RESIZER_IMAGE}
           args:
             - --csi-address=$(ADDRESS)
-            - --timeout=120s
+            - --timeout=300s
             - --v=${LOG_LEVEL}
           env:
             - name: ADDRESS


### PR DESCRIPTION
We wait for approx 287 seconds while resizing the volume,
having a shorter context timeout is problematic because context will
expire before driver is finished waiting for volume to be resized

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1877084

cc @openshift/sig-storage 