### PR TITLE
Bug 1876791: Add default fsType to provisioned PVs

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -60,6 +60,7 @@ spec:
           image: ${PROVISIONER_IMAGE}
           args:
             - --csi-address=$(ADDRESS)
+            - --default-fstype=ext4
             - --feature-gates=Topology=true
             - --v=${LOG_LEVEL}
           env:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -133,6 +133,7 @@ spec:
           image: ${PROVISIONER_IMAGE}
           args:
             - --csi-address=$(ADDRESS)
+            - --default-fstype=ext4
             - --feature-gates=Topology=true
             - --v=${LOG_LEVEL}
           env:


### PR DESCRIPTION
This is needed after rebase to external-provisioner v2.0.0, which does not set any default fsType.

@openshift/storage 