### PR TITLE
Bug 1879406: Use port 10300-10301 for liveness probes

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -47,7 +47,8 @@ spec:
                   key: aws_secret_access_key
           ports:
             - name: healthz
-              containerPort: 19808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10301
               protocol: TCP
           volumeMounts:
             - name: socket-dir
@@ -115,6 +116,19 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/csi/sockets/pluginproxy/
             name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10301
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
           resources:
             requests:
               memory: 50Mi

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -41,7 +41,8 @@ spec:
               mountPath: /dev
           ports:
             - name: healthz
-              containerPort: 9808
+              # Due to hostNetwork, this port is open on all nodes!
+              containerPort: 10300
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -86,6 +87,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
+            - --health-port=10300
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -120,7 +120,8 @@ spec:
                   key: aws_secret_access_key
           ports:
             - name: healthz
-              containerPort: 19808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10301
               protocol: TCP
           volumeMounts:
             - name: socket-dir
@@ -188,6 +189,19 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/csi/sockets/pluginproxy/
             name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10301
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
           resources:
             requests:
               memory: 50Mi
@@ -325,7 +339,8 @@ spec:
               mountPath: /dev
           ports:
             - name: healthz
-              containerPort: 9808
+              # Due to hostNetwork, this port is open on all nodes!
+              containerPort: 10300
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -370,6 +385,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
+            - --health-port=10300
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
[9xxx range is allowed to be accessible from outside of nodes](https://github.com/openshift/openshift-docs/blob/master/modules/installation-network-user-infra.adoc) and we don't need that for CSI driver liveness probes.

Using 10300 does not make it blocked by firewall, but at least it's not in the list of open ports and it's blocked in IPI.

Also add the liveness probe sidecar to controller pod(s), they have the port open, but nobody was listening there.