### PR TITLE
assets/controller.yaml: support using aws config for credentials

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -41,17 +41,29 @@ spec:
                 secretKeyRef:
                   name: ebs-cloud-credentials
                   key: aws_access_key_id
+                  optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: ebs-cloud-credentials
                   key: aws_secret_access_key
+                  optional: true
+            - name: AWS_SDK_LOAD_CONFIG
+              value: '1'
+            - name: AWS_CONFIG_FILE
+              value: /var/run/secrets/aws/credentials
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!
               containerPort: 10301
               protocol: TCP
           volumeMounts:
+            - name: aws-credentials
+              mountPath: /var/run/secrets/aws
+              readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
@@ -136,5 +148,16 @@ spec:
               memory: 50Mi
               cpu: 10m
       volumes:
+        - name: aws-credentials
+          secret:
+            secretName: ebs-cloud-credentials
+        # This service account token can be used to provide identity outside the cluster.
+        # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
         - name: socket-dir
           emptyDir: {}

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -114,17 +114,29 @@ spec:
                 secretKeyRef:
                   name: ebs-cloud-credentials
                   key: aws_access_key_id
+                  optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: ebs-cloud-credentials
                   key: aws_secret_access_key
+                  optional: true
+            - name: AWS_SDK_LOAD_CONFIG
+              value: '1'
+            - name: AWS_CONFIG_FILE
+              value: /var/run/secrets/aws/credentials
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!
               containerPort: 10301
               protocol: TCP
           volumeMounts:
+            - name: aws-credentials
+              mountPath: /var/run/secrets/aws
+              readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
@@ -209,6 +221,17 @@ spec:
               memory: 50Mi
               cpu: 10m
       volumes:
+        - name: aws-credentials
+          secret:
+            secretName: ebs-cloud-credentials
+        # This service account token can be used to provide identity outside the cluster.
+        # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
         - name: socket-dir
           emptyDir: {}
 `)


### PR DESCRIPTION
xref: https://issues.redhat.com/browse/CO-1298

The controller currently accepts the access key & secret key directly from the secret. This makes sure the pod starts after the secret is populated.

With this change, we mount the same secret to the pod to ensure that the pod starts after secret is created. But the env vars sources are updated to optional
since these keys might no longer be present in secret that is using aws config to configure the AWS SDK.

`AWS_SDK_LOAD_CONFIG` and `AWS_CONFIG_FILE` env variables are added to make sure the SDK tried to load the crendetials from the file specified. In cases
where the secret does not have the credentials key, this file will not exist and SDK will skip non-readable files see https://github.com/aws/aws-sdk-go/blob/87f0aa4be0153f21470e7a9802ebfb3403faa9ce/aws/session/shared_config.go#L164-L166

What about when both access key & secret key and credential file is present in the secret. For cred-minter managed secrets these will have the same content, therefore it does not matter which the SDk uses, but for
user provided secret, the preference is decided by the AWS SDK (as it should be) which currently is env > config.

A bound-sa-token is added to the pod and mounted to the csi-driver pod to allow AWS SDK config file to point to it for use with AssumeRoleWithWebhookToken sts call.