### PR TITLE
Bug 1898851: Add multipods tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -25,3 +25,4 @@ DriverInfo:
     nodeExpansion: true
     snapshotDataSource: true
     topology: true
+    multipods: true


### PR DESCRIPTION
AWS EBS supports running multiple pods with as single volume on a single node, let's test it.
@openshift/storage 