### PR TITLE
WIP: Add openshift-tests binary into stable:aws-ebs-csi-driver-operator-test image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,12 @@
+# Image from where we copy openshift-tests.
+FROM registry.svc.ci.openshift.org/ocp/4.5:tests AS test-builder
+
+
 # "src" is build by a prow job when building final images.
 # It contains full repository sources + jq + pyhon with yaml module.
 # Use it as test image for the operator.
 
 FROM src
+
+# Copy openshift-tests into the operator test image - it contains CSI certification tests.
+COPY --from=test-builder /usr/bin/openshift-tests /usr/bin/openshift-tests


### PR DESCRIPTION
This is necessary to rework the tests to multi-stage workflows - nobody else is going to inject openshift-tests into the test image.