### PR TITLE
Bug 1912945: Set proxy config in Deployment containers

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-controller
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-node
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -76,6 +76,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-controller
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:
@@ -340,6 +342,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-node
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-controller
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:
@@ -181,6 +183,8 @@ apiVersion: apps/v1
 metadata:
   name: aws-ebs-csi-driver-controller
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR uses changes from openshift/library-go#976 to apply the proxy config to the CSI Controller Deployment fixes.

CC @openshift/storage 