### PR TITLE
Bug 1905119: dynamically update controller asset for custom CA bundle

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -54,10 +54,6 @@ spec:
               value: '1'
             - name: AWS_CONFIG_FILE
               value: /var/run/secrets/aws/credentials
-            {{- if .CABundleConfigMap}}
-            - name: AWS_CA_BUNDLE
-              value: /etc/ca/ca-bundle.pem
-            {{- end}}
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!
@@ -70,11 +66,6 @@ spec:
             - name: bound-sa-token
               mountPath: /var/run/secrets/openshift/serviceaccount
               readOnly: true
-            {{- if .CABundleConfigMap}}
-            - name: ca-bundle
-              mountPath: /etc/ca
-              readOnly: true
-            {{- end}}
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
@@ -170,10 +161,5 @@ spec:
             - serviceAccountToken:
                 path: token
                 audience: openshift
-        {{- if .CABundleConfigMap}}
-        - name: ca-bundle
-          configMap:
-            name: {{.CABundleConfigMap}}
-        {{- end}}
         - name: socket-dir
           emptyDir: {}

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -127,10 +127,6 @@ spec:
               value: '1'
             - name: AWS_CONFIG_FILE
               value: /var/run/secrets/aws/credentials
-            {{- if .CABundleConfigMap}}
-            - name: AWS_CA_BUNDLE
-              value: /etc/ca/ca-bundle.pem
-            {{- end}}
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!
@@ -143,11 +139,6 @@ spec:
             - name: bound-sa-token
               mountPath: /var/run/secrets/openshift/serviceaccount
               readOnly: true
-            {{- if .CABundleConfigMap}}
-            - name: ca-bundle
-              mountPath: /etc/ca
-              readOnly: true
-            {{- end}}
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
@@ -243,11 +234,6 @@ spec:
             - serviceAccountToken:
                 path: token
                 audience: openshift
-        {{- if .CABundleConfigMap}}
-        - name: ca-bundle
-          configMap:
-            name: {{.CABundleConfigMap}}
-        {{- end}}
         - name: socket-dir
           emptyDir: {}
 `)

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -2,366 +2,49 @@ package operator
 
 import (
 	"testing"
+	"time"
 
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openshift/aws-ebs-csi-driver-operator/pkg/generated"
 )
-
-const controllerWithoutCABundle = `kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: aws-ebs-csi-driver-controller
-  namespace: openshift-cluster-csi-drivers
-  annotations:
-    config.openshift.io/inject-proxy: csi-driver
-spec:
-  selector:
-    matchLabels:
-      app: aws-ebs-csi-driver-controller
-  serviceName: aws-ebs-csi-driver-controller
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: aws-ebs-csi-driver-controller
-    spec:
-      hostNetwork: true
-      serviceAccount: aws-ebs-csi-driver-controller-sa
-      priorityClassName: system-cluster-critical
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: "NoSchedule"
-      containers:
-        - name: csi-driver
-          image: ${DRIVER_IMAGE}
-          args:
-            - --endpoint=$(CSI_ENDPOINT)
-            - --k8s-tag-cluster-id=${CLUSTER_ID}
-            - --logtostderr
-            - --v=${LOG_LEVEL}
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: ebs-cloud-credentials
-                  key: aws_access_key_id
-                  optional: true
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ebs-cloud-credentials
-                  key: aws_secret_access_key
-                  optional: true
-            - name: AWS_SDK_LOAD_CONFIG
-              value: '1'
-            - name: AWS_CONFIG_FILE
-              value: /var/run/secrets/aws/credentials
-          ports:
-            - name: healthz
-              # Due to hostNetwork, this port is open on a node!
-              containerPort: 10301
-              protocol: TCP
-          volumeMounts:
-            - name: aws-credentials
-              mountPath: /var/run/secrets/aws
-              readOnly: true
-            - name: bound-sa-token
-              mountPath: /var/run/secrets/openshift/serviceaccount
-              readOnly: true
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-provisioner
-          image: ${PROVISIONER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --default-fstype=ext4
-            - --feature-gates=Topology=true
-            - --extra-create-metadata=true
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-attacher
-          image: ${ATTACHER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-resizer
-          image: ${RESIZER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --timeout=300s
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-snapshotter
-          image: ${SNAPSHOTTER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=${LOG_LEVEL}
-          env:
-          - name: ADDRESS
-            value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-          - mountPath: /var/lib/csi/sockets/pluginproxy/
-            name: socket-dir
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-liveness-probe
-          image: ${LIVENESS_PROBE_IMAGE}
-          args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10301
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-      volumes:
-        - name: aws-credentials
-          secret:
-            secretName: ebs-cloud-credentials
-        # This service account token can be used to provide identity outside the cluster.
-        # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
-        - name: bound-sa-token
-          projected:
-            sources:
-            - serviceAccountToken:
-                path: token
-                audience: openshift
-        - name: socket-dir
-          emptyDir: {}
-`
-
-const controllerWithCABundle = `kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: aws-ebs-csi-driver-controller
-  namespace: openshift-cluster-csi-drivers
-  annotations:
-    config.openshift.io/inject-proxy: csi-driver
-spec:
-  selector:
-    matchLabels:
-      app: aws-ebs-csi-driver-controller
-  serviceName: aws-ebs-csi-driver-controller
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: aws-ebs-csi-driver-controller
-    spec:
-      hostNetwork: true
-      serviceAccount: aws-ebs-csi-driver-controller-sa
-      priorityClassName: system-cluster-critical
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: "NoSchedule"
-      containers:
-        - name: csi-driver
-          image: ${DRIVER_IMAGE}
-          args:
-            - --endpoint=$(CSI_ENDPOINT)
-            - --k8s-tag-cluster-id=${CLUSTER_ID}
-            - --logtostderr
-            - --v=${LOG_LEVEL}
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: ebs-cloud-credentials
-                  key: aws_access_key_id
-                  optional: true
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ebs-cloud-credentials
-                  key: aws_secret_access_key
-                  optional: true
-            - name: AWS_SDK_LOAD_CONFIG
-              value: '1'
-            - name: AWS_CONFIG_FILE
-              value: /var/run/secrets/aws/credentials
-            - name: AWS_CA_BUNDLE
-              value: /etc/ca/ca-bundle.pem
-          ports:
-            - name: healthz
-              # Due to hostNetwork, this port is open on a node!
-              containerPort: 10301
-              protocol: TCP
-          volumeMounts:
-            - name: aws-credentials
-              mountPath: /var/run/secrets/aws
-              readOnly: true
-            - name: bound-sa-token
-              mountPath: /var/run/secrets/openshift/serviceaccount
-              readOnly: true
-            - name: ca-bundle
-              mountPath: /etc/ca
-              readOnly: true
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-provisioner
-          image: ${PROVISIONER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --default-fstype=ext4
-            - --feature-gates=Topology=true
-            - --extra-create-metadata=true
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-attacher
-          image: ${ATTACHER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-resizer
-          image: ${RESIZER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --timeout=300s
-            - --v=${LOG_LEVEL}
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-snapshotter
-          image: ${SNAPSHOTTER_IMAGE}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=${LOG_LEVEL}
-          env:
-          - name: ADDRESS
-            value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-          - mountPath: /var/lib/csi/sockets/pluginproxy/
-            name: socket-dir
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-        - name: csi-liveness-probe
-          image: ${LIVENESS_PROBE_IMAGE}
-          args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10301
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-          resources:
-            requests:
-              memory: 50Mi
-              cpu: 10m
-      volumes:
-        - name: aws-credentials
-          secret:
-            secretName: ebs-cloud-credentials
-        # This service account token can be used to provide identity outside the cluster.
-        # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
-        - name: bound-sa-token
-          projected:
-            sources:
-            - serviceAccountToken:
-                path: token
-                audience: openshift
-        - name: ca-bundle
-          configMap:
-            name: kube-cloud-config
-        - name: socket-dir
-          emptyDir: {}
-`
 
 func TestWithCustomCABundle(t *testing.T) {
 	cases := []struct {
-		name     string
-		cm       *corev1.ConfigMap
-		expected string
+		name         string
+		cm           *corev1.ConfigMap
+		inDeployment *appsv1.Deployment
+		expected     *appsv1.Deployment
 	}{
 		{
-			name:     "no configmap",
-			expected: controllerWithoutCABundle,
+			name: "no configmap",
+			inDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+							}},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+							}},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "no CA bundle in configmap",
@@ -374,7 +57,28 @@ func TestWithCustomCABundle(t *testing.T) {
 					"other-key": "other-data",
 				},
 			},
-			expected: controllerWithoutCABundle,
+			inDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+							}},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+							}},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "custom CA bundle",
@@ -387,7 +91,45 @@ func TestWithCustomCABundle(t *testing.T) {
 					"ca-bundle.pem": "a custom bundle",
 				},
 			},
-			expected: controllerWithCABundle,
+			inDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+							}},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "csi-driver",
+								Env: []corev1.EnvVar{{
+									Name:  "AWS_CA_BUNDLE",
+									Value: "/etc/ca/ca-bundle.pem",
+								}},
+								VolumeMounts: []corev1.VolumeMount{{
+									Name:      "ca-bundle",
+									MountPath: "/etc/ca",
+									ReadOnly:  true,
+								}},
+							}},
+							Volumes: []corev1.Volume{{
+								Name: "ca-bundle",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{Name: cloudConfigName},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -397,9 +139,22 @@ func TestWithCustomCABundle(t *testing.T) {
 				resources = append(resources, tc.cm)
 			}
 			kubeClient := fake.NewSimpleClientset(resources...)
-			actual := string(withCustomCABundle(generated.MustAsset, kubeClient)("controller.yaml"))
-			if e, a := tc.expected, actual; e != a {
-				t.Errorf("unexpected controller asset\nexpected:\n%s\ngot:\n%s", e, a)
+			kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, cloudConfigNamespace)
+			cloudConfigInformer := kubeInformersForNamespaces.InformersFor(cloudConfigNamespace).Core().V1().ConfigMaps()
+			cloudConfigLister := cloudConfigInformer.Lister().ConfigMaps(cloudConfigNamespace)
+			stopCh := make(chan struct{})
+			go kubeInformersForNamespaces.Start(stopCh)
+			defer close(stopCh)
+			wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+				return cloudConfigInformer.Informer().HasSynced(), nil
+			})
+			deployment := tc.inDeployment.DeepCopy()
+			err := withCustomCABundle(cloudConfigLister)(nil, deployment)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if e, a := tc.expected, deployment; !equality.Semantic.DeepEqual(e, a) {
+				t.Errorf("unexpected deployment\nwant=%#v\ngot= %#v", e, a)
 			}
 		})
 	}


### PR DESCRIPTION
The determination about whether a custom CA bundle is being used is assessed when the operator starts. This can lead to incorrect behavior if the kube-cloud-config ConfigMap has not yet been created in the openshit-config-managed namespace when the operator starts. Instead of only looking for the ConfigMap at start-up, these changes will have the operator looking for the ConfigMap on every reconcile and adjusting the controller deployment accordingly.