### PR TITLE
Cleanup: Remove serviceName from controller manifest

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     matchLabels:
       app: aws-ebs-csi-driver-controller
-  serviceName: aws-ebs-csi-driver-controller
   replicas: 1
   template:
     metadata:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -82,7 +82,6 @@ spec:
   selector:
     matchLabels:
       app: aws-ebs-csi-driver-controller
-  serviceName: aws-ebs-csi-driver-controller
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Deployment spec doesn't support this property, so we should remove it.