### PR TITLE
Fix kube-rbac-proxy image reference

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -101,7 +101,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9202
@@ -138,7 +138,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9203
@@ -176,7 +176,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9204
@@ -213,7 +213,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9205

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openshift/api v0.0.0-20210331193751-3acddb19d360
 	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210407130542-7b14f5aa606e
+	github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/library-go v0.0.0-20210407130542-7b14f5aa606e h1:7r386mTUjSTgRItIshy2wcTM2po/2j3FZBOCJb1n7NQ=
 github.com/openshift/library-go v0.0.0-20210407130542-7b14f5aa606e/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2 h1:eYdrmOSwRqHhfuPK8bhCSkBRUmCNYkgkOLgnImnz3Rs=
+github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -179,7 +179,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9202
@@ -216,7 +216,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9203
@@ -254,7 +254,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9204
@@ -291,7 +291,7 @@ spec:
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --logtostderr=true
-          image: quay.io/openshift/origin-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9205

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -32,6 +32,7 @@ const (
 	resizerImageEnvName       = "RESIZER_IMAGE"
 	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
 	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
+	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
 
 	infraConfigName = "cluster"
 )
@@ -270,6 +271,11 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec, clusterID str
 	livenessProbe := os.Getenv(livenessProbeImageEnvName)
 	if livenessProbe != "" {
 		pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
+	}
+
+	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
+	if kubeRBACProxy != "" {
+		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
 	}
 
 	// Cluster ID

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -27,6 +27,7 @@ const (
 	driverImageEnvName              = "DRIVER_IMAGE"
 	nodeDriverRegistrarImageEnvName = "NODE_DRIVER_REGISTRAR_IMAGE"
 	livenessProbeImageEnvName       = "LIVENESS_PROBE_IMAGE"
+	kubeRBACProxyImageEnvName       = "KUBE_RBAC_PROXY_IMAGE"
 )
 
 // DaemonSetHookFunc is a hook function to modify the DaemonSet.
@@ -212,6 +213,11 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec) []byte {
 	livenessProbe := os.Getenv(livenessProbeImageEnvName)
 	if livenessProbe != "" {
 		pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
+	}
+
+	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
+	if kubeRBACProxy != "" {
+		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
 	}
 
 	// Log level

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,7 +166,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20210407130542-7b14f5aa606e
+# github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2
 ## explicit
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Use the one provided by CSO in the operator env. variables.
@openshift/storage 