### PR TITLE
Bug 2028484: AWS EBS CSI driver's livenessprobe does not respect operator's loglevel

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -298,6 +298,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=10301
+            - --v=${LOG_LEVEL}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -97,6 +97,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=10300
+            - --v=${LOG_LEVEL}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
When log level is changed in clustercsidriver it needs to propagate to a liveness probe container as well through a value passed to --v argument.