### PR TITLE
Bug 2049671: avoid excessive GET and DELETE in ResourcesSync controller 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220114150019-2499da51153e
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
+	github.com/openshift/library-go v0.0.0-20220315141154-40a8b89abdc2
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774 h1:GeCzQyJQ8biS12aYEbJrirh1DGmub2ZxcrNorMgR4XQ=
-github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220315141154-40a8b89abdc2 h1:m1/VatkvWuMmMETgeaXwq/OsS1z5vL2EIgtKE7GCUbA=
+github.com/openshift/library-go v0.0.0-20220315141154-40a8b89abdc2/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -68,8 +68,8 @@ func NewResourceSyncController(
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
 		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
 
-		configMapGetter: configMapsGetter,
-		secretGetter:    secretsGetter,
+		configMapGetter: v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
+		secretGetter:    v1helpers.CachedSecretGetter(secretsGetter, kubeInformersForNamespaces),
 		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
+# github.com/openshift/library-go v0.0.0-20220315141154-40a8b89abdc2
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
This is a library-go bump to get https://github.com/openshift/library-go/pull/1328.

Copying here a naive benchmark from that PR:

Before this patch, on a fresh-installed cluster, without user workloads, we can see that the amount of requests keep growing:

```
$ oc dev_tool audit -f must-gather.local.6142475801866269614/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-de53ed4750def9ed611ca460c780cc78eece525162747213cfdbb4c26687460c/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 5547 line read failures
count: 206, first: 2022-03-12T08:44:24-03:00, last: 2022-03-12T09:04:49-03:00, duration: 20m24.691542s

Top 10 "DELETE" (of 103 total hits):
    103x [ 11.668456ms] [404-102] /api/v1/namespaces/openshift-cluster-csi-drivers/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]

Top 10 "GET" (of 103 total hits):
    103x [  9.466233ms] [404-102] /api/v1/namespaces/openshift-config-managed/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]
```

After 3 minutes we have 20 more requests:

```
$  oc dev_tool audit -f must-gather.local.4791791518547958434/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-de53ed4750def9ed611ca460c780cc78eece525162747213cfdbb4c26687460c/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 5547 line read failures
count: 226, first: 2022-03-12T08:44:24-03:00, last: 2022-03-12T09:07:51-03:00, duration: 23m26.899552s

Top 10 "DELETE" (of 113 total hits):
    113x [ 10.925663ms] [404-112] /api/v1/namespaces/openshift-cluster-csi-drivers/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]

Top 10 "GET" (of 113 total hits):
    113x [  9.023026ms] [404-112] /api/v1/namespaces/openshift-config-managed/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]
$ oc adm must-gather -- /usr/bin/gather_audit_logs; sleep 180; oc adm must-gather -- /usr/bin/gather_audit_logs
```

With this patch, the count stays the same:

```
$ oc dev_tool audit -f must-gather.local.386413735759890088/registry-build01-ci-openshift-org-ci-ln-m19lrrb-stable-sha256-d8bd3c25f0974f2ceec780f10166cab12b7d73ebb557d0d4a3839575e2cbc6e7/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 2868 line read failures

$ oc dev_tool audit -f must-gather.local.4759162092148356031/registry-build01-ci-openshift-org-ci-ln-m19lrrb-stable-sha256-d8bd3c25f0974f2ceec780f10166cab12b7d73ebb557d0d4a3839575e2cbc6e7/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 2868 line read failures
```

CC @openshift/storage 