### PR TITLE
Reformat for go 1.19

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -320,7 +320,7 @@ func isCustomCABundleUsed(cloudConfigLister corev1listers.ConfigMapNamespaceList
 }
 
 // withCustomTags add tags from Infrastructure.Status.PlatformStatus.AWS.ResourceTags to the driver command line as
-//  --extra-tags=<key1>=<value1>,<key2>=<value2>,...
+// --extra-tags=<key1>=<value1>,<key2>=<value2>,...
 func withCustomTags(infraLister v1.InfrastructureLister) deploymentcontroller.DeploymentHookFunc {
 	return func(spec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		infra, err := infraLister.Get(infrastructureName)


### PR DESCRIPTION
go 1.19 changed formatting, reformat the code.

See https://github.com/openshift/aws-ebs-csi-driver-operator/pull/162 for the formatting failures.

@openshift/storage 