### PR TITLE
OCPBUGS-1904: Only deploy VolumeSnapshotClass when CRD exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220919112502-5eaf4250c423
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e
-	github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865
+	github.com/openshift/library-go v0.0.0-20221017091500-9aea380195f4
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
@@ -22,6 +22,8 @@ require (
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+require k8s.io/apiextensions-apiserver v0.25.0
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -97,7 +99,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/apiserver v0.25.0 // indirect
 	k8s.io/kube-aggregator v0.25.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e h1:ab+BJg7h50pi2/rbMkDSXfYx8w80HLmr7NBs8H1hEvU=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e/go.mod h1:e+TTiBDGWB3O3p3iAzl054x3cZDWhrZ5+jxJRCdEFkA=
-github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865 h1:x7KWaYzkD2KQ3rha9u7OVAfjZpSFTmJRSHb4CHc+CwM=
-github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221017091500-9aea380195f4 h1:4P+w+CZsPS423+31zAQ814+tkrueIdBQLdWXdjrmu20=
+github.com/openshift/library-go v0.0.0-20221017091500-9aea380195f4/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
@@ -2,14 +2,17 @@ package serving
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -17,7 +20,7 @@ import (
 )
 
 func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization,
-	kubeConfigFile string) (*genericapiserver.Config, error) {
+	kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection) (*genericapiserver.Config, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	config := genericapiserver.NewConfig(serializer.NewCodecFactory(scheme))
@@ -31,8 +34,6 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 		return nil, err
 	}
 
-	var lastApplyErr error
-
 	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -44,16 +45,16 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.
-		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
-			lastApplyErr = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
-			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", err)
-				return false, nil
+		if !le.Disable {
+			err := assertAPIConnection(pollCtx, kubeClient, le)
+			if err != nil {
+				return nil, fmt.Errorf("failed checking apiserver connectivity: %w", err)
 			}
-			return true, nil
-		}, pollCtx.Done())
+		}
+
+		err = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
 		if err != nil {
-			return nil, lastApplyErr
+			return nil, fmt.Errorf("error initializing delegating authentication: %w", err)
 		}
 	}
 
@@ -68,18 +69,35 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.
-		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
-			lastApplyErr = authorizationOptions.ApplyTo(&config.Authorization)
-			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authorization (will retry): %v", err)
-				return false, nil
+		if !le.Disable {
+			err := assertAPIConnection(pollCtx, kubeClient, le)
+			if err != nil {
+				return nil, fmt.Errorf("failed checking connectivity: %w", err)
 			}
-			return true, nil
-		}, pollCtx.Done())
+		}
+
+		err := authorizationOptions.ApplyTo(&config.Authorization)
 		if err != nil {
-			return nil, lastApplyErr
+			return nil, fmt.Errorf("error initializing delegating authentication: %w", err)
 		}
 	}
 
 	return config, nil
+}
+
+func assertAPIConnection(ctx context.Context, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection) error {
+	var lastErr error
+	err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+		_, lastErr = kubeClient.CoordinationV1().Leases(le.Namespace).Get(ctx, le.Name, metav1.GetOptions{})
+		if lastErr != nil && !apierrors.IsNotFound(lastErr) {
+			klog.V(4).Infof("Error checking for connectivity to apiserver (GET lease %s/%s): %v", le.Namespace, le.Name, lastErr)
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+	if err != nil {
+		return lastErr
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -269,7 +269,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -368,7 +368,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 }
 
 func (c *StaticResourceController) Name() string {
-	return "StaticResourceController"
+	return c.name
 }
 
 func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -245,7 +245,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865
+# github.com/openshift/library-go v0.0.0-20221017091500-9aea380195f4
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
This depends on https://github.com/openshift/library-go/pull/1404.

When the cluster-csi-snapshot-controller-operator is not deployed, (through the CSISnapshot capability) the `VolumeSnapshotClass` CRD is not created at all. In that case, it doesn't make sense to deploy the CR, otherwise the operator gets degraded.

CC @openshift/storage 