### PR TITLE
[release-4.12] OCPBUGS-1904: Don't deploy VolumeSnapshotClass in static controller

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -198,7 +198,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		assets.ReadFile,
 		[]string{
 			"storageclass_gp2.yaml",
-			"volumesnapshotclass.yaml",
 			"csidriver.yaml",
 			"node_sa.yaml",
 			"rbac/privileged_role.yaml",


### PR DESCRIPTION
https://github.com/openshift/aws-ebs-csi-driver-operator/pull/159 was created before https://github.com/openshift/aws-ebs-csi-driver-operator/pull/164, but the latter merged first. As a result, we had to rebase and refactor the former to accommodate the new functionality, introducing this regression.

CC @openshift/storage 