### PR TITLE
OCPBUGS-4491: hypershift: use correct kubeconfig secret

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -530,7 +530,7 @@ func withHypershiftDeploymentHook(isHypershift bool, hypershiftImage string) dc.
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						// FIXME: use a ServiceAccount from the guest cluster
-						SecretName: "admin-kubeconfig",
+						SecretName: "service-network-admin-kubeconfig",
 					},
 				},
 			},


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-4491