### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -48,6 +48,10 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -123,4 +127,12 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
+            type: Directory
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
             type: Directory


### PR DESCRIPTION
To support "mount -o context=XYZ", `/etc/selinux` and `/sys/fs/selinux` from the host must be present in the CSI driver container.

This should not have any visible effect to users, however, it allows us to test Kubernetes `SELinuxMountReadWriteOncePod` feature in OCP when it's enabled via `CustomNoUpgrade` FeatureGates.