### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -26,3 +26,4 @@ DriverInfo:
     snapshotDataSource: true
     topology: true
     multipods: true
+    multiplePVsSameID: true


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage 

(I am curious what happens when the test manifest has an unknown capability, the capability will be available after Kubernetes rebase lands in origin)