### PR TITLE
add dependabot config for gomod updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+  labels:
+    - "docs-approved"
+    - "qe-approved"
+    - "px-approved"
+  reviewers:
+    - "openshift/storage"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We want to try out dependabot on this repo and see how it goes.
/cc @openshift/storage
No customer visible changes from this.
/label docs-approved
/label qe-approved
/label px-approved
