### PR TITLE
OCPBUGS-7837: do not inject-proxy when deploying in hypershift control plane

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -532,6 +532,10 @@ func withHypershiftDeploymentHook(isHypershift bool, hypershiftImage string) dc.
 			return nil
 		}
 
+		// Remove inject-proxy annotations
+		delete(deployment.Annotations, "config.openshift.io/inject-proxy")
+		delete(deployment.Annotations, "config.openshift.io/inject-proxy-cabundle")
+
 		deployment.Spec.Template.Spec.PriorityClassName = hypershiftPriorityClass
 
 		// Inject into the pod the volumes used by CSI and token minter sidecars.


### PR DESCRIPTION
hypershift proxy conformance is failing because dynamic PVs are failing to provision because the `aws-ebs-csi-driver-operator` is configured with proxy when it shouldn't be

https://k8s-testgrid.appspot.com/redhat-hypershift#4.13-conformance-aws-ovn-proxy&width=20

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn-proxy/1627865954157334528/artifacts/conformance-aws-ovn-proxy/dump/artifacts/namespaces/clusters-5dc04e74aa4e7c327a93/apps/deployments/aws-ebs-csi-driver-controller.yaml