### PR TITLE
OCPBUGS-8752: feat: add workload annotation to deployment and daemonset

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -17,6 +17,14 @@ spec:
       maxSurge: 0
   template:
     metadata:
+      annotation:
+        # This annotation allows the workload pinning feature to work when clusters are configured for it.
+        # An admission webhook will look for this annotation when Pod admission occurs to modify the
+        # memory and cpu resources to a custom resource name that the schedular will use to correctly 
+        # assign Pods in a workload pinned cluster. This annotation will be stripped from Pods when 
+        # the cluster is not configured for workload pinning.
+        # See (openshift/enhancements#1213) for more info.
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: aws-ebs-csi-driver-controller
     spec:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -16,6 +16,14 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotation:
+        # This annotation allows the workload pinning feature to work when clusters are configured for it.
+        # An admission webhook will look for this annotation when Pod admission occurs to modify the
+        # memory and cpu resources to a custom resource name that the schedular will use to correctly 
+        # assign Pods in a workload pinned cluster. This annotation will be stripped from Pods when 
+        # the cluster is not configured for workload pinning.
+        # See (openshift/enhancements#1213) for more info.
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: aws-ebs-csi-driver-node
     spec:


### PR DESCRIPTION
Add annotation to controller deployment and node daemonset for workload pinning, this allows workload admission webhook to correctly modify the resources to allow the workload pinning feature to operate as desired.

Related to the enhancements below:
https://github.com/openshift/enhancements/pull/703
https://github.com/openshift/enhancements/pull/1213