### PR TITLE
OCPBUGS-13017: assets/hypershift/controller_sa: Set controller ServiceAccount imagePullSecrets

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed *.yaml rbac/*.yaml
+//go:embed *.yaml hypershift/*.yaml rbac/*.yaml
 var f embed.FS
 
 // ReadFile reads and returns the content of the named file.

--- a/assets/hypershift/controller_sa.yaml
+++ b/assets/hypershift/controller_sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-ebs-csi-driver-controller-sa
+  namespace: ${NAMESPACE}
+imagePullSecrets:
+- name: pull-secret

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -152,6 +152,15 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if err != nil {
 		return err
 	}
+	staticResourceFiles := []string{
+		"controller_pdb.yaml",
+		"cabundle_cm.yaml",
+	}
+	if isHypershift {
+		staticResourceFiles = append(staticResourceFiles, "hypershift/controller_sa.yaml")
+	} else {
+		staticResourceFiles = append(staticResourceFiles, "controller_sa.yaml")
+	}
 
 	var hostedControlPlaneLister cache.GenericLister
 	var hostedControlPlaneInformer cache.SharedInformer
@@ -185,11 +194,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		controlPlaneDynamicClient,
 		controlPlaneKubeInformersForNamespaces,
 		assetWithNamespaceFunc(controlPlaneNamespace),
-		[]string{
-			"controller_sa.yaml",
-			"controller_pdb.yaml",
-			"cabundle_cm.yaml",
-		},
+		staticResourceFiles,
 	).WithCSIConfigObserverController(
 		"AWSEBSDriverCSIConfigObserverController",
 		guestConfigInformers,


### PR DESCRIPTION
Allowing the controller pod to access private images, such as those built by cluster-bot.  The controller analog to
openshift/cluster-storage-operator@63811bd3b9 (openshift/cluster-storage-operator#346).