### PR TITLE
STOR-1167: Enable extra-create-metadata to tag snapshots

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -278,6 +278,7 @@ spec:
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
             - --leader-election-namespace=openshift-cluster-csi-drivers
             - --v=${LOG_LEVEL}
+            - --extra-create-metadata
           env:
           - name: ADDRESS
             value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
This is required by the new driver feature ["Interpolated tags in VolumeSnapshotClass"](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md#snapshot-tagging).

cc @openshift/storage 