### PR TITLE
OCPBUGS-11882: Added safe-to-evict-local-volume annotation from bound-sa-token to ebs-controller

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -25,7 +25,7 @@ spec:
         # the cluster is not configured for workload pinning.
         # See (openshift/enhancements#1213) for more info.
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "socket-dir"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "bound-sa-token,socket-dir"
       labels:
         app: aws-ebs-csi-driver-controller
     spec:


### PR DESCRIPTION
Last PR regarding this topic: https://github.com/openshift/aws-ebs-csi-driver-operator/pull/231

Initially in the deployment were not pretty clear, but once the HostedControlPlane is deployed, that volume shows as another emptyDir volume, so we need to add it to the annotation.

More details here: https://github.com/openshift/hypershift/pull/2647#issuecomment-1577532195