### PR TITLE
[release-4.13] OCPBUGS-14888: Added safe-to-evict-local-volume annotation to aws-ebs-csi-driver-controller pods

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -25,7 +25,7 @@ spec:
         # the cluster is not configured for workload pinning.
         # See (openshift/enhancements#1213) for more info.
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "socket-dir"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "bound-sa-token,socket-dir"
       labels:
         app: aws-ebs-csi-driver-controller
     spec:

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -20,11 +20,12 @@ spec:
       annotations:
         # This annotation allows the workload pinning feature to work when clusters are configured for it.
         # An admission webhook will look for this annotation when Pod admission occurs to modify the
-        # memory and cpu resources to a custom resource name that the schedular will use to correctly 
-        # assign Pods in a workload pinned cluster. This annotation will be stripped from Pods when 
+        # memory and cpu resources to a custom resource name that the schedular will use to correctly
+        # assign Pods in a workload pinned cluster. This annotation will be stripped from Pods when
         # the cluster is not configured for workload pinning.
         # See (openshift/enhancements#1213) for more info.
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "socket-dir"
       labels:
         app: aws-ebs-csi-driver-controller
     spec:


### PR DESCRIPTION
Manual cherry pick from:

- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/231
- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/232

Which includes the annotations for safe eviction of local volumes by the autoscaler.