### PR TITLE
Remove "get" verb from "events" resource of RBAC for provisioner sidecar

### DIFF
--- a/assets/rbac/provisioner_role.yaml
+++ b/assets/rbac/provisioner_role.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list"]


### PR DESCRIPTION
Let's keep `assets/rbac/provisioner_role.yaml` in sync with upstream (https://github.com/openshift/csi-external-provisioner/blob/master/deploy/kubernetes/rbac.yaml)