### PR TITLE
STOR-1461: Remove existing path from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@
 *.out
 
 _output
-aws-ebs-csi-driver-operator


### PR DESCRIPTION
`aws-ebs-csi-driver-operator` in `.gitignore` matches
`cmd/aws-ebs-csi-driver-operator`, which is in the repository and must not be ignored.

cc @openshift/storage 

This is necessary to get ART builds of csi-operator working - files required for build should not be ignored. See https://github.com/openshift/csi-operator/pull/65