### PR TITLE
WRKLDS-1015: tolerate node-role.kubernetes.io/control-plane:NoExecute

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -39,6 +39,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoExecute"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -749,6 +749,18 @@ func withHypershiftDeploymentHook(isHypershift bool, hypershiftImage string, nam
 				Effect:   corev1.TaintEffectNoSchedule,
 			},
 			{
+				Key:      "hypershift.openshift.io/control-plane",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "true",
+				Effect:   corev1.TaintEffectNoExecute,
+			},
+			{
+				Key:      "node-role.kubernetes.io/control-plane",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "true",
+				Effect:   corev1.TaintEffectNoExecute,
+			},
+			{
 				Key:      "hypershift.openshift.io/cluster",
 				Operator: corev1.TolerationOpEqual,
 				Value:    namespace,


### PR DESCRIPTION
Required to be able to advise customers to follow workflow described in https://github.com/openshift/enhancements/pull/1583. If they want to taint control-plane nodes to avoid any other thing to run there (while enforcing it further with validating admission policies), control plane workloads need to tolerate that taint.