### PR TITLE
[4.14] OCPBUGS-33078: Explicitly reserve 1 attachment for the root disk

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -47,6 +47,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
+            - --reserved-volume-attachments=1
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock


### PR DESCRIPTION
Using a newly introduced option --reserved-volume-attachments, explicitly reserve 1 AWS EBS volume attachment for the root disk and leave the other attachment to PVs/PVCs.

This disables bad heuristics in the CSI driver, see the linked bug.

cc @openshift/storage 