### PR TITLE
OCPBUGS-23000: Add annotation to prevent autoscaler eviction

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -24,6 +24,8 @@ spec:
         # the cluster is not configured for workload pinning.
         # See (openshift/enhancements#1213) for more info.
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # This annotation prevents eviction from the cluster-autoscaler
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: aws-ebs-csi-driver-node
     spec:


### PR DESCRIPTION
This change adds an annotation to the daemonset, preventing the cluster-autoscaler from evicting the workload during a scaling event